### PR TITLE
Updated Vagrantfile to work with vagrant 1.1 and later

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -52,9 +52,6 @@ Vagrant.configure("2") do |config|
   # View the documentation for the provider you're using for more
   # information on available options.
 
-  config.ssh.max_tries = 40
-  config.ssh.timeout   = 120
-
   # The path to the Berksfile to use with Vagrant Berkshelf
   # config.berkshelf.berksfile_path = "./Berksfile"
 


### PR DESCRIPTION
config.ssh.max_tries and config.ssh.timeout are no longer available.
