### PR TITLE
fixed uninstallable version of mysql-python

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-WTF==0.8
 Jinja2==2.7
 Mako==0.8.1
 MarkupSafe==0.18
-MySQL-python==1.2.4
+MySQL-python==1.2.5
 Pygments==1.6
 SQLAlchemy==0.8.1
 Sphinx==1.2b1


### PR DESCRIPTION
something odd is causing 1.2.4 to fail when it tries installing, it actually looks like an issue with the version of distribute it trys to install, but none the less 1.2.5 does not have this dependency. And now `pip install -r requirments.txt` works again.
