### PR TITLE
Upgrade MySQL python to prevent install error

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ Flask-WTF==0.8
 Jinja2==2.7
 Mako==0.8.1
 MarkupSafe==0.18
-MySQL-python==1.2.4
+MySQL-python==1.2.5
 Pygments==1.6
 SQLAlchemy==0.8.1
 Sphinx==1.2b1


### PR DESCRIPTION
I did a clean clone and tried to run `pip install -r requirements.txt`. I got an error associated with trying to install `MySQL-python`.

```
...
RuntimeError: maximum recursion depth exceeded
...
IOError: Could not build the egg.
```

After searching around, I saw a recommendation to update to the latest release, 1.2.5. That worked like a charm. But I'm not sure if that's the extent of the issue, so I figure I'd open a ticket and let you handle it.

The app starts up properly with this change. I haven't been able to get the test suite to run successfully. But I suspect that's a different problem.
