### PR TITLE
docs: Fix simple typo, consolodated -> consolidated

### DIFF
--- a/overholt/forms.py
+++ b/overholt/forms.py
@@ -3,7 +3,7 @@
     overholt.forms
     ~~~~~~~~~~~~~~
 
-    consolodated forms module
+    consolidated forms module
 """
 
 from .products.forms import *

--- a/overholt/models.py
+++ b/overholt/models.py
@@ -3,7 +3,7 @@
     overholt.models
     ~~~~~~~~~~~~~~~
 
-    consolodated models module
+    consolidated models module
 """
 
 from .products.models import *


### PR DESCRIPTION
There is a small typo in overholt/forms.py, overholt/models.py.

Should read `consolidated` rather than `consolodated`.

